### PR TITLE
Fixed the unsigned integer issue when using esp-idf framework

### DIFF
--- a/components/ble_adv_handler/ble_adv_handler.cpp
+++ b/components/ble_adv_handler/ble_adv_handler.cpp
@@ -270,7 +270,7 @@ uint8_t BleAdvEncoder::checksum(uint8_t * buf, size_t len) const {
 bool BleAdvEncoder::check_eq(uint32_t ref, uint32_t comp, const char * msg) const {
   if (ref != comp) {
     if (this->debug_mode_) {
-      ESP_LOGD(this->id_.c_str(), "'%s' differs - expected: '0x%X', received: '0x%X'", msg, ref, comp);
+      ESP_LOGD(this->id_.c_str(), "'%s' differs - expected: '0x%lX', received: '0x%X'", msg, ref, comp);
     }
     return false;
   }

--- a/components/ble_adv_handler/ble_adv_handler.cpp
+++ b/components/ble_adv_handler/ble_adv_handler.cpp
@@ -270,7 +270,7 @@ uint8_t BleAdvEncoder::checksum(uint8_t * buf, size_t len) const {
 bool BleAdvEncoder::check_eq(uint32_t ref, uint32_t comp, const char * msg) const {
   if (ref != comp) {
     if (this->debug_mode_) {
-      ESP_LOGD(this->id_.c_str(), "'%s' differs - expected: '0x%lX', received: '0x%X'", msg, ref, comp);
+      ESP_LOGD(this->id_.c_str(), "'%s' differs - expected: '0x%lX', received: '0x%lX'", msg, ref, comp);
     }
     return false;
   }

--- a/components/ble_adv_handler/ble_adv_handler.h
+++ b/components/ble_adv_handler/ble_adv_handler.h
@@ -234,7 +234,7 @@ struct BleAdvConfig_t {
   uint8_t index;
   std::string str() const {
     char str[100] = "";
-    sprintf(str, "  encoding: %s\n  variant: %s\n  forced_id: 0x%X\n  index: %d", 
+    sprintf(str, "  encoding: %s\n  variant: %s\n  forced_id: 0x%lX\n  index: %d", 
             encoding.c_str(), variant.c_str(), forced_id, index);
     return str;
   }


### PR DESCRIPTION
I had an issue when trying to deploy this component on a newer ESP32-C6 board.

This newer board only supports esp-idf framework. And when deploying the component on this board with a framework version newer than the standard version of ESPHome I got an errors about unsigned integer. The issue is documented here: https://github.com/NicoIIT/esphome-components/issues/21

I fixed the issue for my configuration, the changes are small. If you want to merge the code, please test it with your setup as I am not a hardware engineer.